### PR TITLE
Change default API base URL to use HTTP over SSL

### DIFF
--- a/MCKillSwitch/APIs/MCKillSwitchDynamicAPI.m
+++ b/MCKillSwitch/APIs/MCKillSwitchDynamicAPI.m
@@ -34,7 +34,7 @@ NSString * const kMCKillSwitchAPILanguage = @"Accept-Language";
 NSString * const kMCKillSwitchAPIUserAgent = @"User-Agent";
 NSString * const kMCKillSwitchAPIAppVersion = @"version";
 NSString * const kMCKillSwitchAPIPlatform = @"ios";
-NSString * const kMCKillSwitchAPIDefaultAPIBaseURL = @"http://killswitch.mirego.com/killswitch";
+NSString * const kMCKillSwitchAPIDefaultAPIBaseURL = @"https://killswitch.mirego.com/killswitch";
 
 //------------------------------------------------------------------------------
 #pragma mark - Private interface


### PR DESCRIPTION
Killswitch est maintenant disponible via HTTPS (en plus de juste HTTP)! Yay! :tada: 

J’ai seulement changé la valeur de `kMCKillSwitchAPIDefaultAPIBaseURL` et je doute que ça soit suffisant pour que le tour soit joué. J’imagine qu’il faut configurer la librairie de networking pour qu’elle puisse faire des requêtes sur des endpoints HTTPS (ou quelque chose similaire).

Bref, ça serait cool si quelqu’un pouvait prendre cette branche (`feature/https-baby`) et la faire fonctionner :smile: 

/cc @stephpaquet @flambert @danylhebreux @vincentroyc @jfmorin 

![](http://i.imgur.com/2q41F1S.gif)
