### PR TITLE
Fix alert disappearing when alert was presented and coming back from background

### DIFF
--- a/MCKillSwitch/MCKillSwitchAlert.m
+++ b/MCKillSwitch/MCKillSwitchAlert.m
@@ -30,7 +30,7 @@
 
 #define STORE_PREFIX @"store:"
 
-typedef void(^MCKillSwitchAlertBlock)();
+typedef void(^MCKillSwitchAlertBlock)(void);
 
 //------------------------------------------------------------------------------
 #pragma mark - Private interface
@@ -106,17 +106,24 @@ typedef void(^MCKillSwitchAlertBlock)();
 }
 
 - (void)hideAlert {
-    if (self.showing) {
-        [self.alertView dismissViewControllerAnimated:YES completion:nil];
-        [self destroyAlertView];
-    }
+    [self hideAlertWithCompletion:nil];
 }
 
 - (void)hideAlertWithCompletion:(MCKillSwitchAlertBlock)completion {
     if (self.showing) {
-        [self.alertView dismissViewControllerAnimated:YES completion:^{ completion(); }];
-        [self destroyAlertView];
-    } else {
+        [self.alertView dismissViewControllerAnimated:YES completion:^{
+            if (completion) {
+                completion();
+            }
+        }];
+        _alertView = nil;
+        _showing = NO;
+
+        if ([self shouldHideAlertAfterButtonAction]) {
+            // Call the delegate if the alert will be hidden completely, not when the alert is hidden to be shown right afterwards
+            [self.delegate killSwitchAlertDidHide:self];
+        }
+    } else if (completion) {
         completion();
     }
 }


### PR DESCRIPTION
**Problem:**
Since version 1.1 of the KillSwitch, when an app displayed the Alert, if the user put the application in the background and came back to application afterwards, the alert was dismissed. The allowed the user to continue to use the "killed" version of the app. 

Each time we present the alert we first hide it and them display it back again. The code was searching for the topMostViewController. Since the previous alert dismiss action was not yet done, it was trying to present an alert in the previous alert and was failing. The previous alert was simply dismissed and the user could continu to use the application.

**Fix**
Add a completion block on the dismiss of the alert and wait for the completion before trying to present a new one.