### PR TITLE
Cleanup MCKillSwitchAlert code so it's harder to break it

### DIFF
--- a/MCKillSwitch/MCKillSwitchAlert.h
+++ b/MCKillSwitch/MCKillSwitchAlert.h
@@ -27,12 +27,11 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #import <Foundation/Foundation.h>
-#import <StoreKit/StoreKit.h>
 #import "MCKillSwitch.h"
 
 @protocol MCKillSwitchAlertDelegate;
 
-@interface MCKillSwitchAlert : NSObject <MCKillSwitchDelegate, SKStoreProductViewControllerDelegate>
+@interface MCKillSwitchAlert : NSObject <MCKillSwitchDelegate>
 
 @property (nonatomic, weak) id<MCKillSwitchAlertDelegate> delegate;
 @property (nonatomic, readonly, getter = isShowing) BOOL showing;


### PR DESCRIPTION
If the app hosting the kill switch tried to present a view controller at the same time the kill switch alert was presented/dismissed, weird behaviour would occur in the app.

Add `MCKillSwitchAlertController` that will be used to know if the kill switch is presented and that will prevent the app from presenting something on top of it (by throwing an exception).

Also cleaned the code by removing a dead function (`destroyAlertView`) and passing the button to execute instead of finding it again by index after recreating the array.

Finally, fixed the `SKStoreProductViewController` that would not be presented if something was already being presented over the root view controller.